### PR TITLE
fix(stack): only top card is draggable

### DIFF
--- a/src/components/core/CardStack.tsx
+++ b/src/components/core/CardStack.tsx
@@ -53,6 +53,7 @@ export function CardStack<T extends StackableItem>({
           key={item.id}
           onSendToBack={() => sendToBack(item.id)}
           className={cardClassName}
+          isDraggable={index === items.length - 1}
         >
           <motion.div
             className="h-full w-full"

--- a/src/components/core/DraggableContainer.tsx
+++ b/src/components/core/DraggableContainer.tsx
@@ -5,12 +5,14 @@ interface DraggableContainerProps {
   children: React.ReactNode;
   onSendToBack?: () => void;
   className?: string;
+  isDraggable?: boolean;
 }
 
 export function DraggableContainer({
   children,
   onSendToBack,
   className,
+  isDraggable = true,
 }: DraggableContainerProps) {
   const { x, y, rotateX, rotateY, handleDragEnd } =
     useCardRotation(onSendToBack);
@@ -18,12 +20,12 @@ export function DraggableContainer({
   return (
     <motion.div
       className={className}
-      style={{ x, y, rotateX, rotateY }}
-      drag
+      style={{ x, y, rotateX, rotateY, pointerEvents: isDraggable ? "auto" : "none" }}
+      drag={isDraggable}
       dragConstraints={{ top: 0, right: 0, bottom: 0, left: 0 }}
       dragElastic={0.6}
-      whileTap={{ cursor: "grabbing" }}
-      onDragEnd={handleDragEnd}
+      whileTap={isDraggable ? { cursor: "grabbing" } : undefined}
+      onDragEnd={isDraggable ? handleDragEnd : undefined}
     >
       {children}
     </motion.div>


### PR DESCRIPTION
Fixes an issue where cards behind the main card were draggable. Now only the top-most card can be dragged:
- CardStack marks only the top card as draggable
- Non-top cards have pointer events disabled so interactions fall through to the top card

No dependency changes.